### PR TITLE
Bulk data load memory safety warning

### DIFF
--- a/docs/bulk-data-loading.md
+++ b/docs/bulk-data-loading.md
@@ -5,7 +5,7 @@ In DuckDB [Appender](https://duckdb.org/docs/data/appender) can be used to effic
 To use an appender in .NET, call the [CreateAppender](xref:DuckDB.NET.Data.DuckDBConnection.CreateAppender(System.String)) method to create and initialize an appender. After you create an appender, use the `CreateRow` and `AppendValue` methods to create rows and append data. Make sure to `Dispose` the appender to avoid data loss.
 
 > [!CAUTION]
-> Data types MUST match the length of the database types exactly. For example when inserting into a UBIGINTEGER column, a ulong such as `0UL` must be used. Writing `0` will cause data corruption and write the values in adjacent memory.
+> Data types **MUST** match the length of the database types **exactly**. For example when inserting into a UBIGINTEGER column, a ulong such as `0UL` must be used. Writing `0` will cause data corruption and write the values in adjacent memory.
 
 [!code-csharp[](../code/ManagedAppender.cs)]
 

--- a/docs/bulk-data-loading.md
+++ b/docs/bulk-data-loading.md
@@ -5,8 +5,9 @@ In DuckDB [Appender](https://duckdb.org/docs/data/appender) can be used to effic
 To use an appender in .NET, call the [CreateAppender](xref:DuckDB.NET.Data.DuckDBConnection.CreateAppender(System.String)) method to create and initialize an appender. After you create an appender, use the `CreateRow` and `AppendValue` methods to create rows and append data. Make sure to `Dispose` the appender to avoid data loss.
 
 > [!CAUTION]
-> Data types **MUST** match the length of the database types **exactly**. For example when inserting into a UBIGINTEGER column, a ulong such as `0UL` must be used. Writing `0` will cause data corruption and write the values in adjacent memory.
+> Data types **MUST** match the length of the database types **exactly**. For example when inserting into a UBIGINTEGER column, a ulong such as `0UL` must be used. Writing `0U` will cause data corruption by writing adjacent memory to the database.
 
+## Example
 [!code-csharp[](../code/ManagedAppender.cs)]
 
 For importing data from CSV, Parquet, JSON and other file types see the DuckDB documentation for [Data Importing](https://duckdb.org/docs/data/overview).

--- a/docs/bulk-data-loading.md
+++ b/docs/bulk-data-loading.md
@@ -4,6 +4,9 @@ In DuckDB [Appender](https://duckdb.org/docs/data/appender) can be used to effic
 
 To use an appender in .NET, call the [CreateAppender](xref:DuckDB.NET.Data.DuckDBConnection.CreateAppender(System.String)) method to create and initialize an appender. After you create an appender, use the `CreateRow` and `AppendValue` methods to create rows and append data. Make sure to `Dispose` the appender to avoid data loss.
 
+> [!CAUTION]
+> Data types MUST match the length of the database types exactly. For example when inserting into a UBIGINTEGER column, a ulong such as `0UL` must be used. Writing `0` will cause data corruption and write the values in adjacent memory.
+
 [!code-csharp[](../code/ManagedAppender.cs)]
 
 For importing data from CSV, Parquet, JSON and other file types see the DuckDB documentation for [Data Importing](https://duckdb.org/docs/data/overview).

--- a/docs/bulk-data-loading.md
+++ b/docs/bulk-data-loading.md
@@ -5,7 +5,7 @@ In DuckDB [Appender](https://duckdb.org/docs/data/appender) can be used to effic
 To use an appender in .NET, call the [CreateAppender](xref:DuckDB.NET.Data.DuckDBConnection.CreateAppender(System.String)) method to create and initialize an appender. After you create an appender, use the `CreateRow` and `AppendValue` methods to create rows and append data. Make sure to `Dispose` the appender to avoid data loss.
 
 > [!CAUTION]
-> Data types **MUST** match the length of the database types **exactly**. For example when inserting into a UBIGINTEGER column, a ulong such as `0UL` must be used. Writing `0U` will cause data corruption by writing adjacent memory to the database.
+> Data types **MUST** match the length of the database types **exactly**. For example when inserting into a UBIGINTEGER column, a ulong such as `0UL` must be used. Writing just `0` will cause data corruption by writing adjacent memory to the database.
 
 ## Example
 [!code-csharp[](../code/ManagedAppender.cs)]


### PR DESCRIPTION
Adds a `> !CAUTION` block to warn people to check their data types. There is significant risk of data corruption, or crashes from access violations, if a wrong sized data type is used.


NB: For the record, I'm concerned with the lack of memory safety in the library proper. I don't think a caution in the documentation should excuse the behaviour of the library with respect to the out of bounds memory reads & writes, but a documentation change can be fixed more quickly.